### PR TITLE
Fix keyboard shortcuts not working in Manifest V3

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -637,7 +637,7 @@ async function handleContextMenuClick(info, tab) {
  * Handle keyboard commands
  */
 async function handleCommands(command) {
-  const tab = await browser.tabs.getCurrent();
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
   
   if (command == "download_tab_as_markdown") {
     const info = { menuItemId: "download-markdown-all" };


### PR DESCRIPTION
## Summary

- Fixed all keyboard shortcuts (Alt+Shift+D, Alt+Shift+C, Alt+Shift+L, etc.) not working

## Problem

The `handleCommands()` function in `service-worker.js` was using `browser.tabs.getCurrent()` to get the active tab when a keyboard shortcut is pressed. However, in Manifest V3, service workers don't run in any tab context, so `browser.tabs.getCurrent()` always returns `undefined`.

This caused all keyboard shortcuts to silently fail because `tab` was `undefined` when passed to functions like `downloadMarkdownFromContext()`.

## Solution

Changed line 640 from:
```javascript
const tab = await browser.tabs.getCurrent();
```

To:
```javascript
const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
```

This matches the pattern already used in `popup.js` (lines 132, 397, 737) and correctly returns the currently active tab.

## Testing

1. Load the extension as unpacked in Chrome (`chrome://extensions/` → Developer mode → Load unpacked → select `src` folder)
2. Navigate to any webpage
3. Set a keyboard shortcut in `chrome://extensions/shortcuts` for "Save current tab as Markdown"
4. Press the shortcut - the page should now download as Markdown

## Affected Commands

All keyboard commands are now fixed:
- `download_tab_as_markdown` - Download current tab as Markdown
- `copy_tab_as_markdown` - Copy current tab as Markdown
- `copy_tab_as_markdown_link` - Copy current tab URL as Markdown link
- `copy_selection_as_markdown` - Copy selection as Markdown
- `copy_selected_tab_as_markdown_link` - Copy selected tabs as Markdown links
- `copy_selection_to_obsidian` - Copy selection to Obsidian
- `copy_tab_to_obsidian` - Copy tab to Obsidian